### PR TITLE
Update spring social connectors.

### DIFF
--- a/app/pom.TEMPLATE.xml
+++ b/app/pom.TEMPLATE.xml
@@ -17,7 +17,9 @@
     <properties>
         <spring.version>4.0.0.RELEASE</spring.version>
         <org.springframework.security.version>3.2.3.RELEASE</org.springframework.security.version>
-        <org.springframework.social.version>1.1.0.RC1</org.springframework.social.version>
+        <org.springframework.social.version>1.1.4.RELEASE</org.springframework.social.version>
+        <org.springframework.social.facebook.version>2.0.3.RELEASE</org.springframework.social.facebook.version>
+        <org.springframework.social.twitter.version>1.1.2.RELEASE</org.springframework.social.twitter.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -147,12 +149,12 @@
         <dependency>
             <groupId>org.springframework.social</groupId>
             <artifactId>spring-social-facebook</artifactId>
-            <version>${org.springframework.social.version}</version>
+            <version>${org.springframework.social.facebook.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.social</groupId>
             <artifactId>spring-social-twitter</artifactId>
-            <version>${org.springframework.social.version}</version>
+            <version>${org.springframework.social.twitter.version}</version>
         </dependency>
 
         <dependency>

--- a/app/src/main/java/org/greengin/nquireit/controllers/users/CustomProviderSignInController2.java
+++ b/app/src/main/java/org/greengin/nquireit/controllers/users/CustomProviderSignInController2.java
@@ -215,6 +215,7 @@ public class CustomProviderSignInController2 implements InitializingBean {
             Connection<?> connection = connectSupport.completeConnection(connectionFactory, request);
             return handleSignIn(connection, connectionFactory, request);
         } catch (Exception e) {
+            e.printStackTrace();
             return signInError(e);
             //logger.error("Exception while completing OAuth 2 connection: ", e);
             //return redirect(URIBuilder.fromUri(signInUrl).queryParam("error", "provider").build().toString());
@@ -252,14 +253,15 @@ public class CustomProviderSignInController2 implements InitializingBean {
     public void afterPropertiesSet() throws Exception {
         this.connectSupport = new ConnectSupport(sessionStrategy);
         this.connectSupport.setUseAuthenticateUrl(true);
-    };
+        connectSupport.setApplicationUrl(applicationUrlBase);
+    }
 
     // internal helpers
 
     private RedirectView handleSignIn(Connection<?> connection, ConnectionFactory<?> connectionFactory, NativeWebRequest request) {
         List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connection);
         if (userIds.size() == 0) {
-            ProviderSignInAttempt signInAttempt = new ProviderSignInAttempt(connection, connectionFactoryLocator, usersConnectionRepository);
+            ProviderSignInAttempt signInAttempt = new ProviderSignInAttempt(connection);//, connectionFactoryLocator, usersConnectionRepository);
             sessionStrategy.setAttribute(request, ProviderSignInAttempt.SESSION_ATTRIBUTE, signInAttempt);
             return redirect(signUpUrl);
         } else if (userIds.size() == 1) {

--- a/app/src/main/java/org/greengin/nquireit/controllers/users/ProfileController.java
+++ b/app/src/main/java/org/greengin/nquireit/controllers/users/ProfileController.java
@@ -253,7 +253,7 @@ public class ProfileController {
             String msgTmpl = "login".equals(action) ? "Sign in with %s" : "Link %s account";
             String scopes = "";
             if ("facebook".equals(provider)) {
-                scopes = "email,user_likes,friends_likes,publish_stream";
+                scopes = "public_profile,user_about_me,email,user_likes,publish_actions";
             } else if ("google".equals(provider)) {
                 scopes = "email";
             } else if ("twitter".equals(provider)) {

--- a/app/src/main/java/org/greengin/nquireit/logic/users/SocialAdapter.java
+++ b/app/src/main/java/org/greengin/nquireit/logic/users/SocialAdapter.java
@@ -26,7 +26,7 @@ public class SocialAdapter implements SignInAdapter, ConnectionSignUp {
         UserProfile currentUser = userServiceBean.currentUser();
         org.springframework.social.connect.UserProfile oauthProfile = connection.fetchUserProfile();
         ConnectionData data = connection.createData();
-        UserProfile user = userServiceBean.providerSignIn(oauthProfile.getUsername(), data.getProviderId(), data.getProviderUserId());
+        UserProfile user = userServiceBean.providerSignIn(oauthProfile.getUsername(), oauthProfile.getEmail(), data.getProviderId(), data.getProviderUserId());
 
         if (user != null) {
             if (currentUser == null || "login".equals(action) || user.equals(currentUser)) {
@@ -45,7 +45,7 @@ public class SocialAdapter implements SignInAdapter, ConnectionSignUp {
         if (current == null) {
             org.springframework.social.connect.UserProfile profile = connection.fetchUserProfile();
             ConnectionData data = connection.createData();
-            UserProfile user = userServiceBean.providerSignIn(profile.getUsername(), data.getProviderId(), data.getProviderUserId());
+            UserProfile user = userServiceBean.providerSignIn(profile.getUsername(), profile.getEmail(), data.getProviderId(), data.getProviderUserId());
 
             return user.getUsername();
         } else {

--- a/app/src/main/java/org/greengin/nquireit/logic/users/UserServiceBean.java
+++ b/app/src/main/java/org/greengin/nquireit/logic/users/UserServiceBean.java
@@ -201,16 +201,18 @@ public class UserServiceBean implements UserDetailsService, InitializingBean {
         return status(connections, request.getSession());
     }
 
-    public UserProfile providerSignIn(String username, String providerId, String providerUserId) {
+    public UserProfile providerSignIn(String username, String email, String providerId, String providerUserId) {
         UserProfile existingUser = context.getUserProfileDao().loadUserByProviderUserId(providerId, providerUserId);
         if (existingUser != null) {
             return existingUser;
         } else {
-            String email = null;
-
-            if (username.matches("^\\S+@\\S+\\.\\S+$")) {
+            if (email == null && username != null && username.matches("^\\S+@\\S+\\.\\S+$")) {
                 email = username;
                 username = username.substring(0, username.indexOf('@'));
+            }
+
+            if (username == null && email != null) {
+                username = email.substring(0, email.indexOf('@'));
             }
 
             String initialUsername = username;

--- a/app/src/main/webapp/WEB-INF/database.xml
+++ b/app/src/main/webapp/WEB-INF/database.xml
@@ -58,5 +58,6 @@
     <bean id="commentsDao" class="org.greengin.nquireit.dao.CommentsDao"/>
     <bean id="textsDao" class="org.greengin.nquireit.dao.TextDao"/>
     <bean id="logsDao" class="org.greengin.nquireit.dao.LogsDao"/>
+    <bean id="filterDao" class="org.greengin.nquireit.dao.FilterDao"/>
 
 </beans>

--- a/app/src/test/java/org/greengin/nquireit/tests/profile/ProfileControllerTests.java
+++ b/app/src/test/java/org/greengin/nquireit/tests/profile/ProfileControllerTests.java
@@ -69,7 +69,7 @@ public class ProfileControllerTests extends TestsBase {
     @Test
     public void testLoggin() throws Exception {
 
-        context.getUsersManager().providerSignIn("username", "provider", "id");
+        context.getUsersManager().providerSignIn("username", "email@test.com","provider", "id");
 
         checkUserCount(1);
         checkUser(0, "username", "provider", "id");

--- a/app/src/test/java/org/greengin/nquireit/tests/profile/SecurityControllerTests.java
+++ b/app/src/test/java/org/greengin/nquireit/tests/profile/SecurityControllerTests.java
@@ -72,7 +72,7 @@ public class SecurityControllerTests extends TestsBase {
     @Test
     public void testLoggin() throws Exception {
 
-        context.getUsersManager().providerSignIn("username", "provider", "id");
+        context.getUsersManager().providerSignIn("username", "email@test.com","provider", "id");
 
         checkUserCount(1);
         checkUser(0, "username", "provider", "id");


### PR DESCRIPTION
- Fix bug with missing "filterDao" (database.xml)
- Updates spring social connectors to latest releases.
- Facebook connector: updated scopes to current API (see ProfileController.java)
- Potential issue: Facebook social controller no longer receives username from auth provider.
This may affect new users. As a fallback solution, if username is null but email is not
null, the name in the email is assumed to be the username. This should not affect existing
Facebook users, as nquireit identifies these by provider user id, which in the case of
Facebook is a number not related to the email or username.