### PR TITLE
fixed bug with bootstrap dropdowns.

### DIFF
--- a/app/nquire-it.iml
+++ b/app/nquire-it.iml
@@ -23,6 +23,7 @@
         <setting name="validation-enabled" value="true" />
         <setting name="provider-name" value="" />
         <datasource-mapping>
+          <factory-entry name="${persistence.unit}" />
           <factory-entry name="nquire-it-jpa" value="dataSource" />
           <factory-entry name="nquire-it-jpa-tests" />
         </datasource-mapping>

--- a/static/src/partials/project/edit/senseit/project-edit-senseit-analysis.html
+++ b/static/src/partials/project/edit/senseit/project-edit-senseit-analysis.html
@@ -16,11 +16,11 @@
                     <span data-ng-if="txEdit.editable(variable)">
                         <span data-ng-if="!$first">, </span>
 
-                        <div class="btn-group">
-                            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                        <div uib-dropdown class="btn-group">
+                            <button uib-dropdown-toggle type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                 {{ v ? v.label() : '?'}} <span class="caret"></span>
                             </button>
-                            <ul class="dropdown-menu" role="menu">
+                            <ul uib-dropdown-menu class="dropdown-menu" role="menu">
                                 <li data-ng-repeat="av in transformations.availableInputVariables(variable, input_index)">
                                     <a href="" data-ng-click="txEdit.setInputVariable(variable.tx, av.id, input_index)">
                                         {{av.label()}}
@@ -45,11 +45,11 @@
     <div data-ng-if="txForm.isOpen()">
         <p>
 
-        <div class="btn-group dropup">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+        <div uib-dropdown class="btn-group dropup">
+            <button uib-dropdown-toggle type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                 <translate>Add transformation</translate> <span class="caret"></span>
             </button>
-            <ul class="dropdown-menu" role="menu">
+            <ul uib-dropdown-menu class="dropdown-menu" role="menu">
                 <li data-ng-repeat="(t, label) in availableTransformations">
                     <a href="" data-ng-click="txEdit.createVariable(t)">{{label}}</a>
                 </li>


### PR DESCRIPTION
HTML templates need to use dropdown-related directives:

- uib-dropdown: which transforms a node into a dropdown.
- uib-dropdown-toggle: which allows the dropdown to be toggled via click.
- uib-dropdown-menu: which transforms a node into the popup menu.

(https://github.com/angular-ui/bootstrap/tree/master/src/dropdown)